### PR TITLE
面接官が面接日程を承認or拒否できるようにする

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,5 +1,6 @@
 class InterviewsController < ApplicationController
   before_action :set_interview, only: [:edit, :update, :destroy]
+  helper_method :current_user?
 
   def index
     @user = User.find(params[:user_id])

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -5,10 +5,10 @@ class InterviewsController < ApplicationController
 
   def index
     @interviews = if current_user?(@user)
-      @user.interviews.order(:scheduled_datetime)
-    else
-      @user.interviews.where(status: :pending).or(@user.interviews.where(status: :rejected)).order(:scheduled_datetime)
-    end
+                    @user.interviews.order(:scheduled_datetime)
+                  else
+                    @user.interviews.where(status: :pending).or(@user.interviews.where(status: :rejected)).order(:scheduled_datetime)
+                  end
   end
 
   def show

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -3,7 +3,11 @@ class InterviewsController < ApplicationController
 
   def index
     @user = User.find(params[:user_id])
-    @interviews = @user.interviews.order(:scheduled_datetime)
+    @interviews = if current_user?(@user)
+      @user.interviews.order(:scheduled_datetime)
+    else
+      @user.interviews.where(status: :pending).or(@user.interviews.where(status: :rejected)).order(:scheduled_datetime)
+    end
   end
 
   def show

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,9 +1,9 @@
 class InterviewsController < ApplicationController
   before_action :set_interview, only: [:edit, :update, :destroy]
+  before_action :set_user, only: [:index, :update]
   helper_method :current_user?
 
   def index
-    @user = User.find(params[:user_id])
     @interviews = if current_user?(@user)
       @user.interviews.order(:scheduled_datetime)
     else
@@ -32,9 +32,8 @@ class InterviewsController < ApplicationController
   end
 
   def update
-    user = User.find(params[:user_id])
-    unless current_user?(user)
-      user.reject_interviews_except(@interview)
+    unless current_user?(@user)
+      @user.reject_interviews_except(@interview)
     end
     if @interview.update(interview_params)
       redirect_to user_interviews_path(params[:user_id]), notice: 'Interview was successfully updated.'
@@ -56,6 +55,10 @@ class InterviewsController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_interview
       @interview = User.find(params[:user_id]).interviews.find(params[:id])
+    end
+
+    def set_user
+      @user = User.find(params[:user_id])
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -27,8 +27,12 @@ class InterviewsController < ApplicationController
   end
 
   def update
+    user = User.find(params[:user_id])
+    unless current_user?(user)
+      user.reject_interviews_except(@interview)
+    end
     if @interview.update(interview_params)
-      redirect_to user_interviews_path(current_user.id), notice: 'Interview was successfully updated.'
+      redirect_to user_interviews_path(params[:user_id]), notice: 'Interview was successfully updated.'
     else
       render :edit
     end
@@ -39,10 +43,14 @@ class InterviewsController < ApplicationController
     redirect_to user_interviews_path(current_user.id), notice: 'Interview was successfully destroyed.'
   end
 
+  def current_user?(user)
+    current_user.id == user.id
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_interview
-      @interview = current_user.interviews.find_by(id: params[:id])
+      @interview = User.find(params[:user_id]).interviews.find(params[:id])
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -54,7 +54,7 @@ class InterviewsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_interview
-      @interview = User.find(params[:user_id]).interviews.find(params[:id])
+      @interview = Interview.find(params[:id])
     end
 
     def set_user

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -2,8 +2,8 @@ class InterviewsController < ApplicationController
   before_action :set_interview, only: [:edit, :update, :destroy]
 
   def index
-    user = User.find(params[:user_id])
-    @interviews = user.interviews.order(:scheduled_datetime)
+    @user = User.find(params[:user_id])
+    @interviews = @user.interviews.order(:scheduled_datetime)
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def index
+    @users = User.where.not(id: current_user.id)
   end
 
   def me

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -4,7 +4,7 @@ class Interview < ApplicationRecord
   validates :user_id, uniqueness: { scope: [:scheduled_datetime] }
 
   def committed?
-    self.status != 'pending'
+    !pending?
   end
 
   def future?

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -8,6 +8,6 @@ class Interview < ApplicationRecord
   end
 
   def future?
-    self.scheduled_datetime.future?
+    scheduled_datetime.future?
   end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,6 +1,7 @@
 class Interview < ApplicationRecord
   belongs_to :user 
   enum status: { pending: 0, accepted: 1, rejected: 2 }
+  validates :user_id, uniqueness: { scope: [:scheduled_datetime] }
 
   def committed?
     self.status != 'pending'

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,4 +1,12 @@
 class Interview < ApplicationRecord
   belongs_to :user 
   enum status: { pending: 0, accepted: 1, rejected: 2 }
+
+  def committed?
+    self.status != 'pending'
+  end
+
+  def future?
+    self.scheduled_datetime.future?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
   end
 
   def interview_datetime
+    accepted_interview = self.interviews.find_by(status: :accepted)
+    accepted_interview.scheduled_datetime
   end
 
   def reject_interviews_except(excepted_interview)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
 
   def interview_datetime
     accepted_interview = self.interviews.find_by(status: :accepted)
-    accepted_interview.scheduled_datetime
+    accepted_interview.scheduled_datetime if accepted_interview
   end
 
   def reject_interviews_except(excepted_interview)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,12 @@ class User < ApplicationRecord
 
   def interview_datetime
   end
+
+  def reject_interviews_except(excepted_interview)
+    self.interviews.each do |interview|
+      unless interview == excepted_interview
+        interview.update(status: :rejected)
+      end
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,16 +7,16 @@ class User < ApplicationRecord
   has_many :interviews, dependent: :destroy
 
   def age
-    (Date.today.to_s(:number).to_i - self.birth_day.to_s(:number).to_i) / 10000
+    (Date.today.to_s(:number).to_i - birth_day.to_s(:number).to_i) / 10000
   end
 
   def interview_datetime
-    accepted_interview = self.interviews.find_by(status: :accepted)
+    accepted_interview = interviews.find_by(status: :accepted)
     accepted_interview.scheduled_datetime if accepted_interview
   end
 
   def reject_interviews_except(excepted_interview)
-    self.interviews.each do |interview|
+    interviews.each do |interview|
       unless interview == excepted_interview
         interview.update(status: :rejected)
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,11 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable, :confirmable
   enum gender: { male: 0, female: 1 }
   has_many :interviews, dependent: :destroy
+
+  def age
+    (Date.today.to_s(:number).to_i - self.birth_day.to_s(:number).to_i) / 10000
+  end
+
+  def interview_datetime
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,9 +10,8 @@ class User < ApplicationRecord
     (Date.today.to_s(:number).to_i - birth_day.to_s(:number).to_i) / 10000
   end
 
-  def interview_datetime
-    accepted_interview = interviews.find_by(status: :accepted)
-    accepted_interview.scheduled_datetime if accepted_interview
+  def accepted_interview
+    interviews.find_by(status: :accepted)
   end
 
   def reject_interviews_except(excepted_interview)

--- a/app/views/interviews/_index_for_interviewer.html.erb
+++ b/app/views/interviews/_index_for_interviewer.html.erb
@@ -5,7 +5,7 @@
   <% interviews.each do |interview| %>
     <% if interview.future? %>
       <%= link_to interview.scheduled_datetime, user_interview_path(user.id, interview.id, params: { interview: { status: :accepted } }),
-      method: 'put', data: { confirm: 'Are you sure?' }, class: "list-group-item" %>
+      method: 'put', data: { confirm: "#{interview.scheduled_datetime} is selected.\nAre you sure?" }, class: "list-group-item" %>
     <% else %>
       <li class="list-group-item disabled"><%= interview.scheduled_datetime %></li>
     <% end %>

--- a/app/views/interviews/_index_for_interviewer.html.erb
+++ b/app/views/interviews/_index_for_interviewer.html.erb
@@ -1,6 +1,6 @@
 <h1><%= user.user_name %>'s Interviews</h1>
 <h2>Current interview datetime: <%= user.interview_datetime ? user.interview_datetime : '-' %></h2>
-<p>Select an interview datetime.</p>
+<p><%= interviews.empty? ? "There is no proposed datetime of interview." : "Select an interview datetime."%></p>
 <div class="list-group">
   <% interviews.each do |interview| %>
     <% if interview.future? %>

--- a/app/views/interviews/_index_for_interviewer.html.erb
+++ b/app/views/interviews/_index_for_interviewer.html.erb
@@ -1,6 +1,11 @@
 <h1><%= user.user_name %>'s Interviews</h1>
 <div class="list-group">
   <% interviews.each do |interview| %>
-    <li class="list-group-item"><%= interview.scheduled_datetime %></li>
+    <% if interview.future? %>
+      <%= link_to interview.scheduled_datetime, user_interview_path(user.id, interview.id, params: { interview: { status: :accepted } }),
+      method: 'put', data: { confirm: 'Are you sure?' }, class: "list-group-item" %>
+    <% else %>
+      <li class="list-group-item disabled"><%= interview.scheduled_datetime %></li>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/interviews/_index_for_interviewer.html.erb
+++ b/app/views/interviews/_index_for_interviewer.html.erb
@@ -1,5 +1,5 @@
 <h1><%= user.user_name %>'s Interviews</h1>
-<h2>Current interview datetime: <%= user.interview_datetime ? user.interview_datetime : '-' %></h2>
+<h2>Current interview datetime: <%= user.accepted_interview ? user.accepted_interview.scheduled_datetime : '-' %></h2>
 <p><%= interviews.empty? ? "There is no proposed datetime of interview." : "Select an interview datetime."%></p>
 <div class="list-group">
   <% interviews.each do |interview| %>

--- a/app/views/interviews/_index_for_interviewer.html.erb
+++ b/app/views/interviews/_index_for_interviewer.html.erb
@@ -1,4 +1,6 @@
 <h1><%= user.user_name %>'s Interviews</h1>
+<h2>Current interview datetime: <%= user.interview_datetime ? user.interview_datetime : '-' %></h2>
+<p>Select an interview datetime.</p>
 <div class="list-group">
   <% interviews.each do |interview| %>
     <% if interview.future? %>

--- a/app/views/interviews/_index_for_interviewer.html.erb
+++ b/app/views/interviews/_index_for_interviewer.html.erb
@@ -1,0 +1,6 @@
+<h1><%= user.user_name %>'s Interviews</h1>
+<div class="list-group">
+  <% interviews.each do |interview| %>
+    <li class="list-group-item"><%= interview.scheduled_datetime %></li>
+  <% end %>
+</div>

--- a/app/views/interviews/_index_for_me.html.erb
+++ b/app/views/interviews/_index_for_me.html.erb
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
       <% interviews.each do |interview| %>
-        <tr>
+        <tr class=<%= interview.status == 'accepted' ? "success" : "" %>>
           <td><%= interview.scheduled_datetime %></td>
           <td><%= interview.status.capitalize %></td>
           <% button_state = interview.committed? ? "disabled" : "active" %>

--- a/app/views/interviews/_index_for_me.html.erb
+++ b/app/views/interviews/_index_for_me.html.erb
@@ -14,9 +14,10 @@
         <tr>
           <td><%= interview.scheduled_datetime %></td>
           <td><%= interview.status.capitalize %></td>
-          <td><%= link_to 'Edit', edit_user_interview_path(current_user.id, interview), class: "btn btn-primary" %></td>
+          <% button_state = interview.committed? ? "disabled" : "active" %>
+          <td><%= link_to 'Edit', edit_user_interview_path(current_user.id, interview), class: "btn btn-primary #{button_state}" %></td>
           <td><%= link_to 'Remove', user_interview_path(current_user.id, interview),
-          method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %></td>
+          method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger #{button_state}" %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/interviews/_index_for_me.html.erb
+++ b/app/views/interviews/_index_for_me.html.erb
@@ -1,0 +1,25 @@
+<h1>My Interviews</h1>
+<div class="panel panel-default">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Datetime</th>
+        <th>Status</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% interviews.each do |interview| %>
+        <tr>
+          <td><%= interview.scheduled_datetime %></td>
+          <td><%= interview.status.capitalize %></td>
+          <td><%= link_to 'Edit', edit_user_interview_path(current_user.id, interview), class: "btn btn-primary" %></td>
+          <td><%= link_to 'Remove', user_interview_path(current_user.id, interview),
+          method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+<%= link_to 'New Interview', new_user_interview_path, class: "btn btn-default" %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,26 +1,5 @@
-<h1>Interviews</h1>
-
-<div class="panel panel-default">
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>Datetime</th>
-        <th>Status</th>
-        <th></th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @interviews.each do |interview| %>
-        <tr>
-          <td><%= interview.scheduled_datetime %></td>
-          <td><%= interview.status.capitalize %></td>
-          <td><%= link_to 'Edit', edit_user_interview_path(current_user.id, interview), class: "btn btn-primary" %></td>
-          <td><%= link_to 'Remove', user_interview_path(current_user.id, interview),
-          method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-</div>
-<%= link_to 'New Interview', new_user_interview_path, class: "btn btn-default" %>
+<% if params[:user_id].to_i == current_user.id %>
+  <%= render 'index_for_me', interviews: @interviews %>
+<% else %>
+  <%= render 'index_for_interviewer', { interviews: @interviews, user: @user } %>
+<% end %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,4 +1,4 @@
-<% if params[:user_id].to_i == current_user.id %>
+<% if current_user?(@user) %>
   <%= render 'index_for_me', interviews: @interviews %>
 <% else %>
   <%= render 'index_for_interviewer', { interviews: @interviews, user: @user } %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -21,7 +21,7 @@
           <td><%= user.age %></td>
           <td><%= user.gender.capitalize %></td>
           <td><%= user.school_name %></td>
-          <td nowrap><%= user.interview_datetime %></td>
+          <td nowrap><%= user.accepted_interview.try(:scheduled_datetime) %></td>
           <td><%= link_to 'Show Interviews', user_interviews_path(user.id), class: "btn btn-primary" %></td>
         </tr>
       <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,2 +1,30 @@
-<h1>Home</h1>
-<p>Hello, world!</p>
+<h1>Users</h1>
+
+<div class="panel panel-default">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Email</th>
+        <th>Age</th>
+        <th>Gender</th>
+        <th>School Name</th>
+        <th>Interview Datetime</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr>
+          <td nowrap><%= user.user_name %></td>
+          <td nowrap><%= user.email %></td>
+          <td><%= user.age %></td>
+          <td><%= user.gender.capitalize %></td>
+          <td><%= user.school_name %></td>
+          <td nowrap><%= user.interview_datetime %></td>
+          <td><%= link_to 'Show Interviews', user_interviews_path(user.id), class: "btn btn-primary" %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/users/me.html.erb
+++ b/app/views/users/me.html.erb
@@ -12,7 +12,7 @@
       </li>
       <li class="list-group-item">
         <div class="row">
-          <div class="col-lg-2"><strong>email: </strong></div>
+          <div class="col-lg-2"><strong>Email: </strong></div>
           <div class="col-lg-4"><%= current_user.email %></div>
         </div>
       </li>

--- a/db/migrate/20180529103459_add_index_to_interview.rb
+++ b/db/migrate/20180529103459_add_index_to_interview.rb
@@ -1,0 +1,5 @@
+class AddIndexToInterview < ActiveRecord::Migration[5.1]
+  def change
+    add_index :interviews, [:user_id, :scheduled_datetime], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180520105102) do
+ActiveRecord::Schema.define(version: 20180529103459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20180520105102) do
     t.integer "user_id"
     t.integer "status", default: 0
     t.index ["id"], name: "index_interviews_on_id"
+    t.index ["user_id", "scheduled_datetime"], name: "index_interviews_on_user_id_and_scheduled_datetime", unique: true
     t.index ["user_id"], name: "index_interviews_on_user_id"
   end
 


### PR DESCRIPTION
## やりたかったこと

* 自分以外のユーザーの一覧をトップページに表示する
	* 各ユーザーの情報と各ユーザーの面接一覧へのリンクを表示
* 自分の面接一覧を見たときと、他人の面接一覧を見たときとで表示内容を切り替える
	* 自分：面接日程のCRUDができる
	* 他人：面接日程の承認ができる
* 他人の面接日程を承認or拒否できるようにする
	* 面接日程を選択したら、その日が承認されたことを保存＆他の日が拒否されたことを保存

## 主にやったこと

* `user#index`では、`where`句を使って自分以外のユーザーを取得するようにした
* 誰の面接一覧を表示するかによって、`interviews#index`が返すインタビュー一覧を変えるようにした
* パーシャルを使って、自分の面接一覧と、他人の面接一覧のViewを分けた
* `User`モデルに、選択された日以外のすべての面接日程を拒否状態にするメソッドを追加した

## 動作確認方法

### 事前準備
- [ ] 面接官用のアカウント(以後、A)と、面接を受ける人用のアカウント(以後、B)、計２つのアカウントを用意する
- [ ] Bで面接候補日程を作成する

### 動作確認
- [ ] Aでトップページにアクセスして、自分以外のユーザーの一覧が表示されていることを確認する
- [ ] Bの`Show Interviews`をクリックして、面接日程選択ページへいく
- [ ] 任意の日程を面接日として選択する
	* 過去の日程は選択できないようにしました
- [ ] 日程選択後、面接予定日が上部に表示されることを確認する
- [ ] トップページへ戻って、Bの`Interview Datetime`に先ほど選択した日程が表示されていることを確認する 
- [ ]  Bでログインし直して、Bの面接日程を確認する
	* 選択した日程が`Accepted`、その他の日程が`Rejected`
- [ ] 面接日程の編集または新規作成から同じ日程の面接が複数存在できないことを確認する

---
デプロイ先：https://e-navigator-otuhs-r.herokuapp.com/